### PR TITLE
Fix seat crash on dedicated server

### DIFF
--- a/src/main/java/net/luckystudio/cozyhome/CozyHome.java
+++ b/src/main/java/net/luckystudio/cozyhome/CozyHome.java
@@ -5,10 +5,11 @@ import net.luckystudio.cozyhome.block.ModBlocks;
 import net.luckystudio.cozyhome.block.util.ModBlockEntityTypes;
 import net.luckystudio.cozyhome.block.util.interfaces.SinkBehavior;
 import net.luckystudio.cozyhome.components.ModDataComponents;
-import net.luckystudio.cozyhome.util.ModFlammableBlocks;
-import net.luckystudio.cozyhome.util.ModFuels;
+import net.luckystudio.cozyhome.entity.ModEntities;
 import net.luckystudio.cozyhome.item.ModItemGroups;
 import net.luckystudio.cozyhome.item.ModItems;
+import net.luckystudio.cozyhome.util.ModFlammableBlocks;
+import net.luckystudio.cozyhome.util.ModFuels;
 import net.luckystudio.cozyhome.util.ModSoundEvents;
 import net.minecraft.util.Identifier;
 import org.slf4j.Logger;
@@ -22,6 +23,7 @@ public class CozyHome implements ModInitializer {
 	public void onInitialize() {
 		ModItems.registerModItems();
 		ModBlocks.registerModBlocks();
+		ModEntities.registerModEntities();
 		SinkBehavior.registerBehavior();
 		ModBlockEntityTypes.registerBlockEntities();
 		ModItemGroups.registerModItemGroups();

--- a/src/main/java/net/luckystudio/cozyhome/entity/ModEntities.java
+++ b/src/main/java/net/luckystudio/cozyhome/entity/ModEntities.java
@@ -12,4 +12,6 @@ public class ModEntities {
             Registries.ENTITY_TYPE,
             Identifier.of("cozyhome", "seat"),
             EntityType.Builder.create(SeatEntity::new, SpawnGroup.CREATURE).dimensions(1f, 1f).build());
+
+    public static void registerModEntities() {}
 }


### PR DESCRIPTION
Closes #9.

The reason behind this crash on the dedicated server was that the ModEntities class wasn't loaded until much later, whereas on the client it would be loaded by CozyHomeClient, thus allowing the registration to occur.